### PR TITLE
Adopt empty array behavior in parser and validator

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -103,10 +103,21 @@ func (p *parser) parseArray() (Type, error) {
 		return Type{}, fmt.Errorf("unexpected token %s", tok.String())
 	}
 
-	// parse the internal type
-	t, err := p.parseType()
-	if err != nil {
-		return Type{}, err
+	// peek at the next character
+	tok, _ = p.scanIgnoreWhitespace(true)
+	p.unscan()
+
+	var childType *Type
+	if tok != SQUARECLOSE {
+
+		// parse the internal type
+		t, err := p.parseType()
+		if err != nil {
+			return Type{}, err
+		}
+
+		childType = &t
+
 	}
 
 	// parse the closing brace
@@ -115,7 +126,7 @@ func (p *parser) parseArray() (Type, error) {
 		return Type{}, fmt.Errorf("unexpected token %s", tok.String())
 	}
 
-	return Type{Kind: Array, Items: &t}, nil
+	return Type{Kind: Array, Items: childType}, nil
 }
 
 func (p *parser) parseObject() (Type, error) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -50,6 +50,10 @@ func TestParser(t *testing.T) {
 			}},
 		},
 		{
+			Schema: `[]?`,
+			Parsed: Type{Kind: Array, Optional: true, Items: nil},
+		},
+		{
 			Schema: `[number?]`,
 			Parsed: Type{Kind: Array, Items: &Type{
 				Kind:     Number,

--- a/validator.go
+++ b/validator.go
@@ -197,6 +197,10 @@ func validArray(d *json.Decoder, t Type) bool {
 	defer d.Token()
 
 	for d.More() {
+		if t.Items == nil {
+			log.Println("validation failed: array: array is not empty")
+			return false
+		}
 		if ok := valid(d, *t.Items); !ok {
 			log.Println("validation failed: array: invalid sub-element")
 			return false

--- a/validator_test.go
+++ b/validator_test.go
@@ -119,6 +119,18 @@ func TestValid(t *testing.T) {
 		},
 
 		{
+			Type:     Type{Kind: Array, Optional: false, Items: nil},
+			TestData: json.RawMessage(`[]`),
+			Valid:    true,
+		},
+
+		{
+			Type:     Type{Kind: Array, Optional: false, Items: nil},
+			TestData: json.RawMessage(`[1, 2, 3, null]`),
+			Valid:    false,
+		},
+
+		{
 			Type: Type{Kind: Object, Optional: false, Properties: map[string]*Type{
 				"foo": &Type{Kind: Null},
 				"bar": &Type{Kind: Number},


### PR DESCRIPTION
This commit implements the proposal in issue #5 (Proposal: Permit
empty arrays) by correctly parsing the new syntax and correctly
handling validation.

This resolves #5.